### PR TITLE
Add placeholders for GitHub Pages

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -3,4 +3,7 @@
 ## theme: dinky@v0.2.0
 ## theme: hacker@v0.2.0 # a dark theme
 ## theme: slate@v0.2.0
-theme: leap-day@v0.2.0
+## theme: leap-day@v0.2.0
+remote_theme: pages-themes/leap-day@v0.2.0
+plugins:
+- jekyll-remote-theme # add this line to the plugins list if you already have one

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+# Configuration file for OTAR3088 GitHub Pages
+## theme: lcayman@v0.2.0
+## theme: dinky@v0.2.0
+## theme: hacker@v0.2.0 # a dark theme
+## theme: slate@v0.2.0
+theme: leap-day@v0.2.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
 # Documentation for OTAR3088: Automated Knowledge Extraction for Biomedical Literature
 
-* ../README.md
+* [../README.md]([../README.html)
 * Annotation Guidelines

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,4 @@
+# Documentation for OTAR3088: Automated Knowledge Extraction for Biomedical Literature
+
+* ../README.md
+* Annotation Guidelines

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
 # Documentation for OTAR3088: Automated Knowledge Extraction for Biomedical Literature
 
-* [../README.md]([../README.html)
+* [../README.md]([../README.md)
 * Annotation Guidelines


### PR DESCRIPTION
This PR intends to create
1. a `docs` folder, and 2 a `docs/index.md` file
as a placeholder for GitHub Pages to hold the project documentation.